### PR TITLE
Test client api  "/{client_id}/epics/" endpoint

### DIFF
--- a/backend/api/client.py
+++ b/backend/api/client.py
@@ -45,7 +45,9 @@ async def read_clients(client_id: str = None):
 
 # Get all selected client's epics
 @router.get("/{client_id}/epics/")
-async def read_clients_epics(client_id: int = None):
+async def read_clients_epics(
+    client_id: int = None, session: Session = Depends(get_session)
+):
     statement = (
         select(Client.id, Client.name, Epic.name)
         .select_from(Client)

--- a/backend/api/client.py
+++ b/backend/api/client.py
@@ -47,7 +47,7 @@ async def read_clients(client_name: str = None):
 @router.get("/{client_id}/epics/")
 async def read_clients(client_id: str = None):
     statement = (
-        select(Client.name, Epic.name)
+        select(Client.id, Client.name, Epic.name)
         .select_from(Client)
         .join(Epic)
         .where(Client.id == client_id)

--- a/backend/api/client.py
+++ b/backend/api/client.py
@@ -45,7 +45,7 @@ async def read_clients(client_id: str = None):
 
 # Get all selected client's epics
 @router.get("/{client_id}/epics/")
-async def read_clients_epics(client_id: str = None):
+async def read_clients_epics(client_id: int = None):
     statement = (
         select(Client.id, Client.name, Epic.name)
         .select_from(Client)
@@ -57,9 +57,9 @@ async def read_clients_epics(client_id: str = None):
 
 
 # Update client
-@router.put("/")
-async def update_clients(client_name: str, new_client_name: str):
-    statement = select(Client).where(Client.name == client_name)
+@router.put("/{client_id}")
+async def update_clients(client_id: int = None, new_client_name: str = None):
+    statement = select(Client).where(Client.id == client_id)
     client_to_update = session.exec(statement).one()
     print(client_to_update)
     client_to_update.name = new_client_name

--- a/backend/api/client.py
+++ b/backend/api/client.py
@@ -45,7 +45,7 @@ async def read_clients(client_id: str = None):
 
 # Get all selected client's epics
 @router.get("/{client_id}/epics/")
-async def read_clients(client_id: str = None):
+async def read_clients_epics(client_id: str = None):
     statement = (
         select(Client.id, Client.name, Epic.name)
         .select_from(Client)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,41 @@
+from fastapi.testclient import TestClient
+import pytest
+import os
+from ..main import app, session
+from sqlmodel import SQLModel, Session, create_engine
+from sqlmodel.pool import StaticPool
+from ..utils import get_session
+
+db_name = "test_db.sqlite"
+test_con = f"sqlite:///{db_name}"
+test_engine = create_engine(
+    test_con, connect_args={"check_same_thread": False}, echo=True
+)
+
+
+@pytest.fixture(name="create_db", scope="session")
+def create_db():
+    # setup
+    SQLModel.metadata.create_all(test_engine)
+    yield
+    # teardown
+    os.remove(db_name)
+
+
+@pytest.fixture(name="session")
+def session_fixture(create_db):
+    create_db
+
+    with Session(test_engine) as session:
+        yield session
+
+
+@pytest.fixture(name="client")
+def client_fixture(session: Session):
+    def get_session_override():
+        return session
+
+    app.dependency_overrides[get_session] = get_session_override
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,3 +1,5 @@
+# A file containing fixtures for testing
+# Fixtures defined here are available for the whole scope
 from fastapi.testclient import TestClient
 import pytest
 import os
@@ -5,6 +7,7 @@ from ..main import app, session
 from sqlmodel import SQLModel, Session, create_engine
 from sqlmodel.pool import StaticPool
 from ..utils import get_session
+
 
 db_name = "test_db.sqlite"
 test_con = f"sqlite:///{db_name}"

--- a/backend/tests/test_epic_api.py
+++ b/backend/tests/test_epic_api.py
@@ -6,48 +6,13 @@ from sqlmodel import SQLModel, Session, create_engine
 from sqlmodel.pool import StaticPool
 from ..api.epic import get_session
 
-db_name = "test_db.sqlite"
-test_con = f"sqlite:///{db_name}"
-test_engine = create_engine(
-    test_con, connect_args={"check_same_thread": False}, echo=True
-)
 
-# Creates the DB and Deletes it after ALL tests are run thanks to scope=module
-@pytest.fixture(name="create_db", scope="module")
-def create_db():
-    # setup
-    SQLModel.metadata.create_all(test_engine)
-    yield
-    # teardown
-    os.remove(db_name)
-
-
-@pytest.fixture(name="session")
-def session_fixture(create_db):
-    create_db
-
-    with Session(test_engine) as session:
-        yield session
-
-
-@pytest.fixture(name="client")
-def client_fixture(session: Session):
-    def get_session_override():
-        return session
-
-    app.dependency_overrides[get_session] = get_session_override
-    client = TestClient(app)
-    yield client
-    app.dependency_overrides.clear()
-
-
+@pytest.mark.order(1)
 def test_post_epic(client):
     response = client.post(
         "/api/epics/",
         json={"name": "[dyvenia]branding", "work_area": "DYV", "client_id": 1},
     )
-    app.dependency_overrides.clear()
-
     data = response.json()
     assert response.status_code == 200
     assert data == {
@@ -91,6 +56,7 @@ def test_get_epic_list(client):
     ]
 
 
+@pytest.mark.order(-1)
 def test_delete_epics(client):
     response = client.delete("/api/epics/?epic_name=[dyvenia]branding")
     assert response.status_code == 200


### PR DESCRIPTION
New features:
-  test for  client api  "/{client_id}/epics/" endpoint
- test fixtures moved to a new file conftest.py
- ordering tested endpoints by `pytest-order`